### PR TITLE
fix(ci): skip image push for forked pull requests

### DIFF
--- a/.github/workflows/docker-build-test-push-template.yml
+++ b/.github/workflows/docker-build-test-push-template.yml
@@ -23,21 +23,25 @@ on:
         description: Package path
         required: false
         type: string
-        default: 'docker/'
+        default: "docker/"
       ci_registry:
-        description: "The registry used to push ci images"
+        description: The registry used to push CI images
         required: false
         type: string
         default: "ghcr.io"
+
+permissions:
+  contents: read
+  packages: write
 
 defaults:
   run:
     shell: bash
 
 jobs:
-
   docker-build-test-push:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Repo ⚡️
         uses: actions/checkout@v6
@@ -51,9 +55,24 @@ jobs:
       - name: Set up container registry 📦
         id: ci_registry
         run:  |
-            echo "ci_registry=${{ vars.CI_REGISTRY || inputs.ci_registry }}" >> $GITHUB_OUTPUT
-            echo "registry_repo=${{ vars.CI_REGISTRY || inputs.ci_registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
-            echo "image=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
+          echo "ci_registry=${{ vars.CI_REGISTRY || inputs.ci_registry }}" >> "$GITHUB_OUTPUT"
+          echo "registry_repo=${{ vars.CI_REGISTRY || inputs.ci_registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
+          echo "image=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate CI push policy 🔎
+        id: push-policy
+        run: |
+          can_push_ci=true
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            head_repo="$(jq -r '.pull_request.head.repo.full_name // ""' "$GITHUB_EVENT_PATH")"
+
+            if [[ "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
+              can_push_ci=false
+            fi
+          fi
+
+          echo "can_push_ci=$can_push_ci" >> "$GITHUB_OUTPUT"
 
       - name: Get Git Branch Name Action
         id: get-branch
@@ -66,10 +85,15 @@ jobs:
       - name: Set CI image tag
         id: image-tag
         run: |
-            echo "ci_tag=${{ steps.ci_registry.outputs.registry_repo }}/${{ steps.ci_registry.outputs.image }}:${{ steps.get-branch.outputs.branch }}" >> $GITHUB_OUTPUT
-            echo "Set image tags to: $IMAGE_TAGS"
+          branch="${{ steps.get-branch.outputs.branch }}"
+          tag_branch="$(echo "$branch" | sed 's#/#--#g')"
+          ci_tag="${{ steps.ci_registry.outputs.registry_repo }}/${{ steps.ci_registry.outputs.image }}:${tag_branch}"
+
+          echo "ci_tag=$ci_tag" >> "$GITHUB_OUTPUT"
+          echo "Set image tag to: $ci_tag"
 
       - name: Login into ${{ steps.ci_registry.outputs.ci_registry }} registry 🔐
+        if: steps.push-policy.outputs.can_push_ci == 'true'
         uses: docker/login-action@v4
         with:
           registry: ${{ steps.ci_registry.outputs.ci_registry }}
@@ -82,7 +106,5 @@ jobs:
           context: .
           file: ${{ inputs.path }}Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ steps.push-policy.outputs.can_push_ci == 'true' }}
           tags: ${{ steps.image-tag.outputs.ci_tag }}
-
-


### PR DESCRIPTION
## Description

This PR updates the Docker CI workflow to safely handle pull requests opened from forked repositories.

Before this change, the workflow always logged in to the CI registry and always pushed the Docker image:

```yaml
push: true
```

This works for same-repository pull requests and trusted events, but fails for forked pull requests because they do not have write access to the package registry.

This PR adds a CI push policy that detects whether the workflow is running from a forked pull request.

Behavior after this change:

```text
same-repository PR / trusted event -> build + login + push CI image
forked PR                          -> build only, no registry login, no image push
```

The workflow now skips registry login and disables Docker image push for forked pull requests, while preserving the existing push behavior for trusted CI runs.

This PR also fixes the CI image tag step by removing the undefined `IMAGE_TAGS` variable and logging the actual generated `ci_tag`.

## Related Issue

Fixes #

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / chore
* [ ] Breaking change

## How to Test

1. Open a pull request from a branch inside the same repository.

   Expected result:

   ```text
   CI registry login runs
   Docker image is built
   Docker image is pushed to the CI registry
   ```

2. Open a pull request from a forked repository.

   Expected result:

   ```text
   CI registry login is skipped
   Docker image is built
   Docker image is not pushed
   Workflow does not fail because of registry write permissions
   ```

3. Verify that the generated CI image tag is correctly printed in the workflow logs.

4. Verify that trusted non-PR events still push the CI image as before.

## Checklist

* [x] I have tested my changes
* [x] Documentation updated if needed
* [x] If breaking change: migration path described above
* [x] I hereby declare this contribution to be licensed under the [[Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)](http://www.apache.org/licenses/LICENSE-2.0).
* [x] I hereby agree to grant [[TOSIT](https://www.tosit.io/)](https://www.tosit.io/) a copyright license to use my contributions.