### PR TITLE
fix(ci): harden GitHub Actions security and enable Dependabot updates

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
         # this might remove tools that are actually needed,
         # if set to "true" but frees about 6 GB
@@ -35,6 +35,4 @@ runs:
         large-packages: true
         docker-images: true
         swap-storage: true
-
-
 

--- a/.github/actions/git-branch/action.yml
+++ b/.github/actions/git-branch/action.yml
@@ -38,16 +38,23 @@ runs:
   steps:
     - name: Get branch name
       id: git-branch
+      env:
+        EVENT_NAME: ${{ inputs.event_name }}
+        HEAD_REF: ${{ inputs.head_ref }}
+        REF: ${{ inputs.ref }}
       run: |
-        if [[ "${{ inputs.event_name }}" == "push" ]]; then
-          BRANCH_NAME="${GITHUB_REF##*/}"
-        elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          BRANCH_NAME="${GITHUB_REF##*/}"
-        elif [[ "${{ inputs.event_name }}" == "pull_request" ]]; then
-          BRANCH_NAME="${{ inputs.head_ref }}"
+        if [[ "$EVENT_NAME" == "push" ]]; then
+          BRANCH_NAME="${REF#refs/heads/}"
+        elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          BRANCH_NAME="${REF#refs/heads/}"
+        elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+          BRANCH_NAME="$HEAD_REF"
+        else
+          echo "Unsupported event: $EVENT_NAME" >&2
+          exit 1
         fi
         # Convert branch name to lowercase and replace '/' with '-'
         BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
         echo "Branch name: $BRANCH_NAME"
-        echo "branch=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+        echo "branch=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/helm-docs/action.yml
+++ b/.github/actions/helm-docs/action.yml
@@ -31,12 +31,18 @@ runs:
   steps:
 
     - name: Install helm-docs
+      env:
+        HELM_DOCS_VERSION: ${{ inputs.helm_docs_version }}
       run: |
-        wget https://github.com/norwoodj/helm-docs/releases/download/v${{ inputs.helm_docs_version }}/helm-docs_${{ inputs.helm_docs_version }}_Linux_x86_64.deb
-        sudo apt install ./helm-docs_${{ inputs.helm_docs_version }}_Linux_x86_64.deb
-        rm -f helm-docs_${{ inputs.helm_docs_version }}_Linux_x86_64.deb
+        if [[ ! "$HELM_DOCS_VERSION" =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
+          echo "Invalid helm-docs version: $HELM_DOCS_VERSION" >&2
+          exit 1
+        fi
+
+        package="helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.deb"
+        url="https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/${package}"
+
+        curl -fsSLO "$url"
+        sudo apt install "./$package"
+        rm -f "$package"
       shell: bash
-
-    
-
-

--- a/.github/actions/latest-image-tag/action.yml
+++ b/.github/actions/latest-image-tag/action.yml
@@ -36,20 +36,28 @@ runs:
       id: git-release-tag
       run: |
         LATEST_GIT_TAG=$(gh release ls -L 200 --json tagName --jq '.[].tagName|select(all(.; contains("helm") | not))' | head -1)
-        LATEST_TAG=$(echo $LATEST_GIT_TAG | tr -d 'v')
-        echo "latest_git_tag=${LATEST_GIT_TAG}" >> $GITHUB_OUTPUT
-        echo "latest_tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
-        echo "image=${GITHUB_REPOSITORY#*/}" >> $GITHUB_OUTPUT
+        if [[ -z "$LATEST_GIT_TAG" ]]; then
+          echo "No non-helm GitHub release tag found" >&2
+          exit 1
+        fi
+
+        LATEST_TAG=$(echo "$LATEST_GIT_TAG" | tr -d 'v')
+        echo "latest_git_tag=${LATEST_GIT_TAG}" >> "$GITHUB_OUTPUT"
+        echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+        echo "image=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ github.token }}
       shell: bash
 
     - name: Info - Found latest release tag
+      env:
+        IMAGE: ${{ steps.git-release-tag.outputs.image }}
+        LATEST_GIT_TAG: ${{ steps.git-release-tag.outputs.latest_git_tag }}
+        LATEST_TAG: ${{ steps.git-release-tag.outputs.latest_tag }}
       run: |
-          echo "image: ${{ steps.git-release-tag.outputs.image }}"
-          echo "latest_tag: ${{ steps.git-release-tag.outputs.latest_tag }}"
-          echo "latest_git_tag: ${{ steps.git-release-tag.outputs.latest_git_tag }}"
+          echo "image: $IMAGE"
+          echo "latest_tag: $LATEST_TAG"
+          echo "latest_git_tag: $LATEST_GIT_TAG"
       shell: bash
     
-
 

--- a/.github/actions/makefile-run/action.yml
+++ b/.github/actions/makefile-run/action.yml
@@ -28,7 +28,15 @@ runs:
   steps:
 
     - name: Run tests if enabled
-      run: ${{ inputs.command }}
-      shell: bash
+      env:
+        MAKE_COMMAND: ${{ inputs.command }}
+      run: |
+        if [[ ! "$MAKE_COMMAND" =~ ^make([[:space:]][A-Za-z0-9_./:=+-]+)*$ ]]; then
+          echo "Unsupported make command: $MAKE_COMMAND" >&2
+          exit 1
+        fi
 
+        read -r -a command <<< "$MAKE_COMMAND"
+        "${command[@]}"
+      shell: bash
 

--- a/.github/actions/setup-buildx/action.yaml
+++ b/.github/actions/setup-buildx/action.yaml
@@ -21,9 +21,9 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU 📦
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
     - name: Set up Docker Buildx 📦
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       with:
         driver-opts: network=host

--- a/.github/actions/setup-kind/action.yaml
+++ b/.github/actions/setup-kind/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         # https://github.com/helm/kind-action?tab=readme-ov-file#inputs
         verbosity: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: "06:00"
+      time: "06:07"
       timezone: Europe/Paris
     open-pull-requests-limit: 5
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docker-build-test-push-template.yml
+++ b/.github/workflows/docker-build-test-push-template.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Free up disk space 📦
         uses: okdp/gh-workflows/.github/actions/free-disk-space@v1
@@ -54,9 +54,13 @@ jobs:
 
       - name: Set up container registry 📦
         id: ci_registry
+        env:
+          INPUT_CI_REGISTRY: ${{ inputs.ci_registry }}
+          VAR_CI_REGISTRY: ${{ vars.CI_REGISTRY }}
         run:  |
-          echo "ci_registry=${{ vars.CI_REGISTRY || inputs.ci_registry }}" >> "$GITHUB_OUTPUT"
-          echo "registry_repo=${{ vars.CI_REGISTRY || inputs.ci_registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
+          ci_registry="${VAR_CI_REGISTRY:-$INPUT_CI_REGISTRY}"
+          echo "ci_registry=$ci_registry" >> "$GITHUB_OUTPUT"
+          echo "registry_repo=${ci_registry}/${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
           echo "image=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
 
       - name: Evaluate CI push policy 🔎
@@ -84,24 +88,27 @@ jobs:
 
       - name: Set CI image tag
         id: image-tag
+        env:
+          BRANCH: ${{ steps.get-branch.outputs.branch }}
+          IMAGE: ${{ steps.ci_registry.outputs.image }}
+          REGISTRY_REPO: ${{ steps.ci_registry.outputs.registry_repo }}
         run: |
-          branch="${{ steps.get-branch.outputs.branch }}"
-          tag_branch="$(echo "$branch" | sed 's#/#--#g')"
-          ci_tag="${{ steps.ci_registry.outputs.registry_repo }}/${{ steps.ci_registry.outputs.image }}:${tag_branch}"
+          tag_branch="$(echo "$BRANCH" | sed 's#/#--#g')"
+          ci_tag="${REGISTRY_REPO}/${IMAGE}:${tag_branch}"
 
           echo "ci_tag=$ci_tag" >> "$GITHUB_OUTPUT"
           echo "Set image tag to: $ci_tag"
 
       - name: Login into ${{ steps.ci_registry.outputs.ci_registry }} registry 🔐
         if: steps.push-policy.outputs.can_push_ci == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ steps.ci_registry.outputs.ci_registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image ${{ steps.image-tag.outputs.ci_tag }} 📤
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ${{ inputs.path }}Dockerfile

--- a/.github/workflows/docker-publish-template.yml
+++ b/.github/workflows/docker-publish-template.yml
@@ -29,6 +29,14 @@ on:
         required: false
         type: string
         default: 'quay.io'
+    secrets:
+      REGISTRY_USERNAME:
+        required: true
+      REGISTRY_ROBOT_TOKEN:
+        required: true
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -44,7 +52,7 @@ jobs:
       latest_git_tag: ${{ steps.latest-image-tag.outputs.latest_git_tag }}
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get latest GitHub Release tag name 📥
         id: latest-image-tag
@@ -56,7 +64,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout release tag ${{ needs.latest-image-tag.outputs.latest_git_tag }} ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ needs.latest-image-tag.outputs.latest_git_tag }}
@@ -70,14 +78,18 @@ jobs:
 
       - name: Set up container registry 📦
         id: registry
+        env:
+          INPUT_REGISTRY: ${{ inputs.registry }}
+          VAR_REGISTRY: ${{ vars.REGISTRY }}
         run:  |
-            echo "registry=${{ vars.REGISTRY || inputs.registry }}" >> $GITHUB_OUTPUT
-            echo "registry_repo=${{ vars.REGISTRY || inputs.registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+            registry="${VAR_REGISTRY:-$INPUT_REGISTRY}"
+            echo "registry=$registry" >> "$GITHUB_OUTPUT"
+            echo "registry_repo=${registry}/${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
 
       ### Publish steps
       ### The publish and periodic rebuilds are based on the latest stable github release tag
       - name: Login into ${{ steps.registry.outputs.registry }} registry 🔐
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ steps.registry.outputs.registry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -85,20 +97,24 @@ jobs:
 
       - name: Set image tags
         id: image-tags
+        env:
+          IMAGE: ${{ needs.latest-image-tag.outputs.image }}
+          LATEST_TAG: ${{ needs.latest-image-tag.outputs.latest_tag }}
+          REGISTRY_REPO: ${{ steps.registry.outputs.registry_repo }}
         run: |
-           IMAGE_TAG=$(echo "${{ needs.latest-image-tag.outputs.latest_tag }}" | awk -F- '{ print $1 }')
-           if [ "$IMAGE_TAG" != "${{ needs.latest-image-tag.outputs.latest_tag }}" ]
+           image_tag="$(echo "$LATEST_TAG" | awk -F- '{ print $1 }')"
+           if [ "$image_tag" != "$LATEST_TAG" ]
            then
-             IMAGE_TAGS="${{ steps.registry.outputs.registry_repo }}/${{ needs.latest-image-tag.outputs.image }}:${IMAGE_TAG},"
+             image_tags="${REGISTRY_REPO}/${IMAGE}:${image_tag},"
            fi
 
-           IMAGE_TAGS+="${{ steps.registry.outputs.registry_repo }}/${{ needs.latest-image-tag.outputs.image }}:${{ needs.latest-image-tag.outputs.latest_tag }}"
+           image_tags+="${REGISTRY_REPO}/${IMAGE}:${LATEST_TAG}"
            
-           echo "tags=${IMAGE_TAGS}" >> $GITHUB_OUTPUT
-           echo "Set image tags to: $IMAGE_TAGS"
+           echo "tags=${image_tags}" >> "$GITHUB_OUTPUT"
+           echo "Set image tags to: $image_tags"
 
       - name: Build and push to ${{ steps.registry.outputs.registry_repo }} repository 📤
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ${{ inputs.path }}/Dockerfile
@@ -111,4 +127,3 @@ jobs:
             org.opencontainers.image.description="${{ needs.latest-image-tag.outputs.image }} image"
             org.opencontainers.image.source="https://github.com/${{ github.repository }}"
             org.opencontainers.image.licenses="Apache-2.0"
-

--- a/.github/workflows/helm-docker-release-please-template.yml
+++ b/.github/workflows/helm-docker-release-please-template.yml
@@ -39,26 +39,40 @@ on:
         description: Github released tag name
         required: true
         type: string
+    secrets:
+      REGISTRY_USERNAME:
+        required: true
+      REGISTRY_ROBOT_TOKEN:
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
 
   helm-chart-publish:
     if: inputs.package_type == 'helm'
     name: "Helm publish (${{ inputs.package }}-${{ inputs.version }})"
+    permissions:
+      contents: write
     uses: okdp/gh-workflows/.github/workflows/helm-publish-template.yml@v1
     with:
         path: ${{ inputs.path }}
         chart_name: ${{ inputs.package }}
         version: ${{ inputs.version }}
         git_tag_name: ${{ inputs.git_tag_name }}
-    secrets: inherit
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_ROBOT_TOKEN: ${{ secrets.REGISTRY_ROBOT_TOKEN }}
 
   docker-publish:
     if: inputs.package_type == 'docker'
     name: "Docker publish (${{ inputs.package }}-${{ inputs.version }})"
+    permissions:
+      contents: read
     uses: okdp/gh-workflows/.github/workflows/docker-publish-template.yml@v1
     with:
       path: ${{ inputs.path }}
-    secrets: inherit
-
-
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_ROBOT_TOKEN: ${{ secrets.REGISTRY_ROBOT_TOKEN }}

--- a/.github/workflows/helm-docker-release-please.yml
+++ b/.github/workflows/helm-docker-release-please.yml
@@ -20,9 +20,7 @@ on:
   workflow_call:
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 defaults:
   run:
@@ -31,27 +29,34 @@ defaults:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       github_releases: ${{ steps.github-releases.outputs.result }}
     # Skip the release process in the fork
     # The pull request should come from the same repo (github_token from the fork does not have write permissions)
     if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
       
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: github-releases
+        env:
+          PATHS_RELEASED: ${{ steps.release-please.outputs.paths_released || '[]' }}
+          RELEASE_OUTPUTS: ${{ toJSON(steps.release-please.outputs) }}
         with:
           script: |
-            const paths_released = JSON.parse(JSON.stringify(${{ steps.release-please.outputs.paths_released }}))
-            const releases_output = JSON.parse(JSON.stringify(${{ toJSON(steps.release-please.outputs) }}))
+            const paths_released = JSON.parse(process.env.PATHS_RELEASED || '[]')
+            const releases_output = JSON.parse(process.env.RELEASE_OUTPUTS || '{}')
             const github_releases = []
             for(const path of paths_released){
               github_releases.push(
                 {
                   path: path,
-                  package: path.includes('helm/') ? path.replace(/^.+\//,''): '${{ github.repository }}'.replace(/^.+\//,''),
+                  package: path.includes('helm/') ? path.replace(/^.+\//,''): process.env.GITHUB_REPOSITORY.replace(/^.+\//,''),
                   version: releases_output[`${path}--version`] || releases_output['version'],
                   package_type: path.replace(/^\.|\/.*/, '') || 'docker',
                   tag_name: releases_output[`${path}--tag_name`] || releases_output['version']
@@ -67,6 +72,8 @@ jobs:
       matrix: 
         release: ${{ fromJson(needs.release-please.outputs.github_releases) }}
       fail-fast: false
+    permissions:
+      contents: write
     uses: okdp/gh-workflows/.github/workflows/helm-docker-release-please-template.yml@v1
     with:
       path: ${{ matrix.release.path }}
@@ -74,5 +81,7 @@ jobs:
       version: ${{ matrix.release.version }}
       package_type: ${{ matrix.release.package_type }}
       git_tag_name: ${{ matrix.release.tag_name }}
-    secrets: inherit
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_ROBOT_TOKEN: ${{ secrets.REGISTRY_ROBOT_TOKEN }}
                 

--- a/.github/workflows/helm-lint-template.yml
+++ b/.github/workflows/helm-lint-template.yml
@@ -25,6 +25,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -33,30 +36,34 @@ jobs:
 
   helm-lint:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       
       - name: Setup helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.15.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
   
       - name: Run chart-testing (list-changed) ✅
         id: list-changed
         run: |
             changed=$(ct list-changed --config .ct.yml)
             if [[ -n "$changed" ]]; then
-              echo "list_changed=$(echo ${changed} | tr -d \')" >> "$GITHUB_OUTPUT"
+              changed_single_line="${changed//$'\n'/ }"
+              changed_single_line="${changed_single_line//\'/}"
+              echo "list_changed=$changed_single_line" >> "$GITHUB_OUTPUT"
               echo "changed=true" >> "$GITHUB_OUTPUT"
             fi
   
@@ -65,16 +72,32 @@ jobs:
         run: ct lint --config .ct.yml --check-version-increment=false --print-config
   
       - name: Free up disk space 🧹
-        if: steps.list-changed.outputs.changed == 'true' && inputs.skip_chart_test == 'false'
+        if: steps.list-changed.outputs.changed == 'true' && !inputs.skip_chart_test
         uses: okdp/gh-workflows/.github/actions/free-disk-space@v1
 
       - name: Set up kind cluster ✅
-        if: steps.list-changed.outputs.changed == 'true' && inputs.skip_chart_test == 'false'
+        if: steps.list-changed.outputs.changed == 'true' && !inputs.skip_chart_test
         uses: okdp/gh-workflows/.github/actions/setup-kind@v1
 
       - name: Run chart-testing (install) ✅
-        if: steps.list-changed.outputs.changed == 'true' && inputs.skip_chart_test == 'false'
+        if: steps.list-changed.outputs.changed == 'true' && !inputs.skip_chart_test
         run: ct install --config .ct.yml --print-config
+
+  helm-docs:
+    needs: [helm-lint]
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
+    # Github token from forked repo does not have permission to push to target repo.
+    # Skip the step for PRs from forked repos.
+    if: |
+      (github.event_name == 'push') || (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - name: Checkout Repo ⚡️
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
 
       - name: Install helm-docs
         uses: okdp/gh-workflows/.github/actions/helm-docs@v1
@@ -85,16 +108,10 @@ jobs:
           helm-docs -c .
 
       - name: Commit helm docs changes
-        # Github token from forked repo does not have permission to push to target repo
-        # Skip the step for PRs from forked repos
-        if: |
-            ${{ ((github.event_name == 'push') || (github.event_name == 'pull_request'
-                  && github.event.pull_request.head.repo.full_name == github.repository)) }}
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           pull: "--rebase --autostash"
           add: "**/README.md"
           message: '[helm-docs] Update readme'
           author_name: github-actions[bot]
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
-

--- a/.github/workflows/helm-publish-template.yml
+++ b/.github/workflows/helm-publish-template.yml
@@ -35,10 +35,18 @@ on:
         description: Github released tag name
         required: true
         type: string
+    secrets:
+      REGISTRY_USERNAME:
+        required: true
+      REGISTRY_ROBOT_TOKEN:
+        required: true
   
 env:
   chart_package_name: ${{ inputs.chart_name }}-${{ inputs.version }}.tgz
   cr_release_name_template: "{{ .Name }}-v{{ .Version }}"
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -49,21 +57,26 @@ jobs:
   helm-chart-publish:
     name: "Helm publish (${{ inputs.chart_name }}-${{ inputs.version }})"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
     steps:
       - name: Checkout release tag ${{ inputs.git_tag_name }} ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_tag_name }}
       
       - name: Update release title
-        run: |
-          gh release edit ${{ inputs.git_tag_name }} --title="${{ inputs.chart_name }}-helm-chart-${{ inputs.version }}"
         env:
+          CHART_NAME: ${{ inputs.chart_name }}
+          GIT_TAG_NAME: ${{ inputs.git_tag_name }}
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh release edit "$GIT_TAG_NAME" --title="${CHART_NAME}-helm-chart-${VERSION}"
 
       - name: Setup helm 📦
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.15.1
 
@@ -74,24 +87,29 @@ jobs:
           helm repo update
 
       - name: Install chart-releaser (cr) 📦
-        uses: helm/chart-releaser-action@v1
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           install_only: true
 
       - name: Package helm chart ${{ inputs.path }} (${{ inputs.version }}) 📦
+        env:
+          CHART_PATH: ${{ inputs.path }}
         run: |
-          helm dependency build ${{ inputs.path }}
-          cr package ${{ inputs.path }}
+          helm dependency build "$CHART_PATH"
+          cr package "$CHART_PATH"
     
       - name: Set up oci charts registry 📦
         id: registry
+        env:
+          VAR_REGISTRY: ${{ vars.REGISTRY }}
         run:  |
-            echo "registry=${{ vars.REGISTRY || 'quay.io' }}" >> $GITHUB_OUTPUT
-            echo "registry_repo=${{ vars.REGISTRY || 'quay.io' }}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+            registry="${VAR_REGISTRY:-quay.io}"
+            echo "registry=$registry" >> "$GITHUB_OUTPUT"
+            echo "registry_repo=${registry}/${GITHUB_REPOSITORY_OWNER@L}" >> "$GITHUB_OUTPUT"
      
       # More secure than helm registry login
       - name: Login into ${{ steps.registry.outputs.registry }} oci charts registry 🔐
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ steps.registry.outputs.registry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -104,15 +122,18 @@ jobs:
       #   run: cosign version
 
       - name: Push chart ${{ env.chart_package_name }} to oci registry  📤
+        env:
+          REGISTRY_REPO: ${{ steps.registry.outputs.registry_repo }}
         run: |
-            helm push ./.cr-release-packages/${{ env.chart_package_name }} \
-              oci://${{ steps.registry.outputs.registry_repo }}/charts
+            helm push "./.cr-release-packages/${chart_package_name}" \
+              "oci://${REGISTRY_REPO}/charts"
 
       - name: Upload Chart ${{ env.chart_package_name }} package to Github release  📤
-        run: |
-          gh release upload ${{ inputs.git_tag_name }} ./.cr-release-packages/${{ env.chart_package_name }} --clobber
         env:
+          GIT_TAG_NAME: ${{ inputs.git_tag_name }}
           GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GIT_TAG_NAME" "./.cr-release-packages/${chart_package_name}" --clobber
 
       # - name: Checkout gh-pages branch  ⚡️
       #   uses: actions/checkout@v6

--- a/.github/workflows/makefile-run-template.yml
+++ b/.github/workflows/makefile-run-template.yml
@@ -30,6 +30,9 @@ on:
         type: string
         default: "make test"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -40,12 +43,12 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
   
       - name: Setup Go Environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '${{ inputs.go_version }}'
 
@@ -56,4 +59,3 @@ jobs:
         uses: okdp/gh-workflows/.github/actions/makefile-run@v1
         with:
           command: ${{ inputs.command }}
-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,9 +24,11 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -34,38 +36,46 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     # Skip the release process in the fork
     # The pull request should come from the same repo (github_token from the fork does not have write permissions)
     if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
       
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up GitHub Actions git bot 📦
-        uses: okdp/gh-workflows/.github/actions/setup-git-bot@main
+        uses: ./.github/actions/setup-git-bot
 
         # https://github.com/google-github-actions/release-please-action/blob/main/.github/workflows/release-please.yaml
       - name: Update major tag to the latest tag
         if: ${{ steps.release-please.outputs.release_created }}
+        env:
+          RELEASE_MAJOR: ${{ steps.release-please.outputs.major }}
+          RELEASE_MINOR: ${{ steps.release-please.outputs.minor }}
         run: |
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}"
-          git tag -d v${{ steps.release-please.outputs.major }} || true
-          git tag -d v${{ steps.release-please.outputs.major }}.${{ steps.release-please.outputs.minor }} || true
-          git push origin :v${{ steps.release-please.outputs.major }} || true
-          git push origin :v${{ steps.release-please.outputs.major }}.${{ steps.release-please.outputs.minor }} || true
-          git tag -a v${{ steps.release-please.outputs.major }} -m "Release v${{ steps.release-please.outputs.major }}"
-          git tag -a v${{ steps.release-please.outputs.major }}.${{ steps.release-please.outputs.minor }} -m "Release v${{ steps.release-please.outputs.major }}.${{ steps.release-please.outputs.minor }}"
-          git push origin v${{ steps.release-please.outputs.major }}
-          git push origin v${{ steps.release-please.outputs.major }}.${{ steps.release-please.outputs.minor }}
+          if [[ ! "$RELEASE_MAJOR" =~ ^[0-9]+$ || ! "$RELEASE_MINOR" =~ ^[0-9]+$ ]]; then
+            echo "Invalid release version outputs" >&2
+            exit 1
+          fi
 
-        
+          major_tag="v${RELEASE_MAJOR}"
+          minor_tag="v${RELEASE_MAJOR}.${RELEASE_MINOR}"
+
+          git tag -d "$major_tag" || true
+          git tag -d "$minor_tag" || true
+          git push origin ":refs/tags/${major_tag}" || true
+          git push origin ":refs/tags/${minor_tag}" || true
+          git tag -a "$major_tag" -m "Release $major_tag"
+          git tag -a "$minor_tag" -m "Release $minor_tag"
+          git push origin "refs/tags/${major_tag}"
+          git push origin "refs/tags/${minor_tag}"


### PR DESCRIPTION
## Description

This PR hardens the GitHub Actions workflows and reusable actions used by this repository.

Main changes include:

* Reduce default `GITHUB_TOKEN` permissions and scope write permissions only where needed.
* Pin third-party GitHub Actions to immutable commit SHAs.
* Move GitHub expression values into environment variables before shell execution to reduce injection risks.
* Harden branch-name handling in `.github/actions/git-branch/action.yml`, including support for branch names containing `/`, such as `ci/security`.
* Make secret passing more explicit in reusable workflow calls.
* Add Dependabot configuration for GitHub Actions dependency updates.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / chore
* [ ] Breaking change

## Checklist

* [ ] I have tested my changes
* [ ] Documentation updated if needed
* [ ] If breaking change: migration path described above
* [x] I hereby declare this contribution to be licensed under the [[Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)](http://www.apache.org/licenses/LICENSE-2.0).
* [x] I hereby agree to grant [[TOSIT](https://www.tosit.io/)](https://www.tosit.io/) a copyright license to use my contributions.