### PR TITLE
chore: disable dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       day: monday
       time: "06:07"
       timezone: Europe/Paris
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
See [#2](https://github.com/OKDP/OKDP/issues/27)
